### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jbigkit (2.1-4) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 11:05:23 +0100
+
 jbigkit (2.1-3) unstable; urgency=low
 
   * Fix up typo in man page

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Build-Depends: debhelper (>=8.1.3), libtool
 Standards-Version: 3.9.5
 Section: libs
 Homepage: http://www.cl.cam.ac.uk/~mgk25/jbigkit/
-Vcs-Git: git://github.com/mvanderkolff/jbigkit-packaging.git
+Vcs-Git: https://github.com/mvanderkolff/jbigkit-packaging.git
 Vcs-Browser: https://github.com/mvanderkolff/jbigkit-packaging
 
 Package: jbigkit-bin


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
