### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: jbigkit
 Priority: optional
 Maintainer: Michael van der Kolff <mvanderkolff@gmail.com>
-Build-Depends: debhelper (>=8.1.3), libtool
+Build-Depends: debhelper, libtool
 Standards-Version: 3.9.5
 Section: libs
 Homepage: http://www.cl.cam.ac.uk/~mgk25/jbigkit/


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/jbigkit/f13cf946-188c-413e-bf02-02cfeb3b6f30.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/f13cf946-188c-413e-bf02-02cfeb3b6f30/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/f13cf946-188c-413e-bf02-02cfeb3b6f30/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/f13cf946-188c-413e-bf02-02cfeb3b6f30/diffoscope)).
