### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: jbigkit
 Priority: optional
 Maintainer: Michael van der Kolff <mvanderkolff@gmail.com>
-Build-Depends: debhelper (>=8.1.3), libtool
+Build-Depends: debhelper, libtool
 Standards-Version: 3.9.5
 Section: libs
 Homepage: http://www.cl.cam.ac.uk/~mgk25/jbigkit/


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/jbigkit/70267410-0631-4fe1-9198-92f673b960a1.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/1b/ade279d8b6735849ca65ad1007a746604e48be.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/27/4ed007795ddaac9575fdd54fcad762cefc3032.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/70/234a36648005616cdd878374b5ab5c230c1c12.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/96/cbb35df71d494dcbddd0b88bf1e788277f861b.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/c3/a0f62b5faa6214640e08ff8959a6220c8fca0f.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/2d/12581c5505c6bf462bfbcf04f923e7ee64b3cd.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/57/9cd21b94f6b2178bc3a6a3a1c56a00763e1f37.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/6d/c33fe8cfc06a7f5a0b15dfd90293a2f2a62497.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/b4/2dc2b7c0e2e808a4cc805b34fe9410a179317a.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/c6/af6121b5c360edab30a63faaa3ac6b475b9caa.debug

No differences were encountered between the control files of package \*\*jbigkit-bin\*\*
### Control files of package jbigkit-bin-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-579cd21b94f6b2178bc3a6a3a1c56a00763e1f37 6dc33fe8cfc06a7f5a0b15dfd90293a2f2a62497 b42dc2b7c0e2e808a4cc805b34fe9410a179317a c6af6121b5c360edab30a63faaa3ac6b475b9caa-] {+1bade279d8b6735849ca65ad1007a746604e48be 70234a36648005616cdd878374b5ab5c230c1c12 96cbb35df71d494dcbddd0b88bf1e788277f861b c3a0f62b5faa6214640e08ff8959a6220c8fca0f+}

No differences were encountered between the control files of package \*\*libjbig-dev\*\*

No differences were encountered between the control files of package \*\*libjbig0\*\*
### Control files of package libjbig0-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-2d12581c5505c6bf462bfbcf04f923e7ee64b3cd-] {+274ed007795ddaac9575fdd54fcad762cefc3032+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/70267410-0631-4fe1-9198-92f673b960a1/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/70267410-0631-4fe1-9198-92f673b960a1/diffoscope)).
